### PR TITLE
separate types from implementation

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
-
-	"k8s.io/utils/pointer"
 )
 
 type Agent interface {
@@ -42,5 +40,5 @@ func StrPtr(str string) *string {
 		return nil
 	}
 
-	return pointer.String(str)
+	return &str
 }

--- a/pkg/agent/kubermatic/v1/types/record.go
+++ b/pkg/agent/kubermatic/v1/types/record.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Telemetry Authors.
+Copyright 2021 The Telemetry Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v2
+package types
 
 import (
 	"fmt"
@@ -27,10 +27,8 @@ type Record struct {
 	agent.KindVersion
 	// Time is the time when the record is generated.
 	Time time.Time `json:"time"`
-	// KubermaticEdition is the Kubermatic edition type
-	KubermaticEdition string `json:"kubermatic_edition"`
-	// KubermaticVersion is the Kubermatic Release Version.
-	KubermaticVersion string `json:"kubermatic_version"`
+	// Kubernetes version of this cluster.
+	KubernetesVersion string `json:"kubernetes_version"`
 	// Seeds is a list of seed-specific information.
 	Seeds []Seed `json:"seeds,omitempty"`
 	// Clusters is a list of cluster-specific information.
@@ -85,9 +83,6 @@ type Cluster struct {
 	// ProjectUUID helps to uniquely relate this cluster with the owned project
 	ProjectUUID string `json:"project_uuid,omitempty"`
 
-	// CNIPlugin contains the spec of the CNI plugin to be installed in the cluster.
-	CNIPlugin CNIPluginSettings `json:"cni_plugin,omitempty"`
-
 	// ExposeStrategy is the approach we use to expose this cluster, either via NodePort
 	// or via a dedicated LoadBalancer
 	ExposeStrategy string `json:"expose_strategy,omitempty"`
@@ -97,42 +92,20 @@ type Cluster struct {
 	// Version defines the wanted version of the control plane
 	KubernetesServerVersion string `json:"kubernetes_server_version,omitempty"`
 
+	// KubermaticVersion current kubermatic version.
+	KubermaticVersion string `json:"kubermatic_version,omitempty"`
+
 	// Cloud specifies the cloud providers configuration
 	Cloud Cloud `json:"cloud,omitempty"`
 
 	// OPAIntegration is a preview feature that enables OPA integration with Kubermatic for the cluster.
 	OPAIntegrationEnabled bool `json:"opa_integration_enabled"`
 
-	ClusterNetwork ClusterNetworkingConfig `json:"cluster_network"`
-
 	// MLA contains monitoring, logging and alerting related settings for the user cluster.
 	MLA MLASettings `json:"mla,omitempty"`
 
 	// EnableUserSSHKeyAgent control whether the UserSSHKeyAgent will be deployed in the user cluster or not.
 	UserSSHKeyAgentEnabled bool `json:"user_ssh_key_agent_enabled"`
-}
-
-// ClusterNetworkingConfig specifies the different networking
-// parameters for a cluster.
-type ClusterNetworkingConfig struct {
-	// Optional: IP family used for cluster networking. Supported values are "", "IPv4" or "IPv4+IPv6".
-	// Can be omitted / empty if pods and services network ranges are specified.
-	// In that case it defaults according to the IP families of the provided network ranges.
-	// If neither ipFamily nor pods & services network ranges are specified, defaults to "IPv4".
-	// +optional
-	IPFamily string `json:"ip_family,omitempty"`
-
-	// KonnectivityEnabled enables konnectivity for controlplane to node network communication.
-	KonnectivityEnabled bool `json:"konnectivity_enabled,omitempty"`
-}
-
-// CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.
-type CNIPluginSettings struct {
-	// Type defines the type of CNI plugin installed.
-	// Possible values are `canal`, `cilium` or `none`.
-	Type string `json:"type"`
-	// Version defines the CNI plugin version to be used. This varies by chosen CNI plugin type.
-	Version string `json:"version"`
 }
 
 type Cloud struct {

--- a/pkg/agent/kubermatic/v2/types/record.go
+++ b/pkg/agent/kubermatic/v2/types/record.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Telemetry Authors.
+Copyright 2023 The Telemetry Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package types
 
 import (
 	"fmt"
@@ -27,8 +27,10 @@ type Record struct {
 	agent.KindVersion
 	// Time is the time when the record is generated.
 	Time time.Time `json:"time"`
-	// Kubernetes version of this cluster.
-	KubernetesVersion string `json:"kubernetes_version"`
+	// KubermaticEdition is the Kubermatic edition type
+	KubermaticEdition string `json:"kubermatic_edition"`
+	// KubermaticVersion is the Kubermatic Release Version.
+	KubermaticVersion string `json:"kubermatic_version"`
 	// Seeds is a list of seed-specific information.
 	Seeds []Seed `json:"seeds,omitempty"`
 	// Clusters is a list of cluster-specific information.
@@ -83,6 +85,9 @@ type Cluster struct {
 	// ProjectUUID helps to uniquely relate this cluster with the owned project
 	ProjectUUID string `json:"project_uuid,omitempty"`
 
+	// CNIPlugin contains the spec of the CNI plugin to be installed in the cluster.
+	CNIPlugin CNIPluginSettings `json:"cni_plugin,omitempty"`
+
 	// ExposeStrategy is the approach we use to expose this cluster, either via NodePort
 	// or via a dedicated LoadBalancer
 	ExposeStrategy string `json:"expose_strategy,omitempty"`
@@ -92,20 +97,42 @@ type Cluster struct {
 	// Version defines the wanted version of the control plane
 	KubernetesServerVersion string `json:"kubernetes_server_version,omitempty"`
 
-	// KubermaticVersion current kubermatic version.
-	KubermaticVersion string `json:"kubermatic_version,omitempty"`
-
 	// Cloud specifies the cloud providers configuration
 	Cloud Cloud `json:"cloud,omitempty"`
 
 	// OPAIntegration is a preview feature that enables OPA integration with Kubermatic for the cluster.
 	OPAIntegrationEnabled bool `json:"opa_integration_enabled"`
 
+	ClusterNetwork ClusterNetworkingConfig `json:"cluster_network"`
+
 	// MLA contains monitoring, logging and alerting related settings for the user cluster.
 	MLA MLASettings `json:"mla,omitempty"`
 
 	// EnableUserSSHKeyAgent control whether the UserSSHKeyAgent will be deployed in the user cluster or not.
 	UserSSHKeyAgentEnabled bool `json:"user_ssh_key_agent_enabled"`
+}
+
+// ClusterNetworkingConfig specifies the different networking
+// parameters for a cluster.
+type ClusterNetworkingConfig struct {
+	// Optional: IP family used for cluster networking. Supported values are "", "IPv4" or "IPv4+IPv6".
+	// Can be omitted / empty if pods and services network ranges are specified.
+	// In that case it defaults according to the IP families of the provided network ranges.
+	// If neither ipFamily nor pods & services network ranges are specified, defaults to "IPv4".
+	// +optional
+	IPFamily string `json:"ip_family,omitempty"`
+
+	// KonnectivityEnabled enables konnectivity for controlplane to node network communication.
+	KonnectivityEnabled bool `json:"konnectivity_enabled,omitempty"`
+}
+
+// CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.
+type CNIPluginSettings struct {
+	// Type defines the type of CNI plugin installed.
+	// Possible values are `canal`, `cilium` or `none`.
+	Type string `json:"type"`
+	// Version defines the CNI plugin version to be used. This varies by chosen CNI plugin type.
+	Version string `json:"version"`
 }
 
 type Cloud struct {

--- a/pkg/agent/kubernetes/v1/agent.go
+++ b/pkg/agent/kubernetes/v1/agent.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubermatic/telemetry-client/pkg/agent"
 	"github.com/kubermatic/telemetry-client/pkg/agent/kubernetes"
+	v1types "github.com/kubermatic/telemetry-client/pkg/agent/kubernetes/v1/types"
 	"github.com/kubermatic/telemetry-client/pkg/datastore"
 	telemetryversion "github.com/kubermatic/telemetry-client/pkg/version"
 
@@ -61,7 +62,7 @@ func (a kubernetesAgent) Collect(ctx context.Context) error {
 		return err
 	}
 
-	record := Record{
+	record := v1types.Record{
 		KindVersion: agent.KindVersion{
 			Kind:    "kubernetes",
 			Version: telemetryversion.V1Version,
@@ -91,12 +92,12 @@ func (a kubernetesAgent) Collect(ctx context.Context) error {
 	return a.dataStore.Store(ctx, data)
 }
 
-func nodeFromKubeNode(kn corev1.Node) (Node, error) {
+func nodeFromKubeNode(kn corev1.Node) (v1types.Node, error) {
 	id, err := getID(kn)
 	if err != nil {
-		return Node{}, err
+		return v1types.Node{}, err
 	}
-	n := Node{
+	n := v1types.Node{
 		ID:                      id,
 		OperatingSystem:         agent.StrPtr(kn.Status.NodeInfo.OperatingSystem),
 		OSImage:                 agent.StrPtr(kn.Status.NodeInfo.OSImage),
@@ -114,7 +115,7 @@ func nodeFromKubeNode(kn corev1.Node) (Node, error) {
 	sort.Strings(keys)
 	for _, k := range keys {
 		v := kn.Status.Capacity[corev1.ResourceName(k)]
-		n.Capacity = append(n.Capacity, Resource{
+		n.Capacity = append(n.Capacity, v1types.Resource{
 			Resource: k,
 			Value:    v.String(),
 		})

--- a/pkg/agent/kubernetes/v1/types/record.go
+++ b/pkg/agent/kubernetes/v1/types/record.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2021 The Telemetry Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,10 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Telemetry takes the Record schema from Kubernetes spartakus project:
-https://github.com/kubernetes-retired/spartakus/blob/master/pkg/volunteer/kubernetes.go
-and some customized fields are added to fit Telemetry own use cases.
 */
 
 package types

--- a/pkg/agent/kubernetes/v1/types/record.go
+++ b/pkg/agent/kubernetes/v1/types/record.go
@@ -18,7 +18,7 @@ https://github.com/kubernetes-retired/spartakus/blob/master/pkg/volunteer/kubern
 and some customized fields are added to fit Telemetry own use cases.
 */
 
-package v1
+package types
 
 import (
 	"fmt"

--- a/pkg/agent/kubernetes/v2/agent.go
+++ b/pkg/agent/kubernetes/v2/agent.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubermatic/telemetry-client/pkg/agent"
 	"github.com/kubermatic/telemetry-client/pkg/agent/kubernetes"
+	v2types "github.com/kubermatic/telemetry-client/pkg/agent/kubernetes/v2/types"
 	"github.com/kubermatic/telemetry-client/pkg/datastore"
 	telemetryversion "github.com/kubermatic/telemetry-client/pkg/version"
 
@@ -61,7 +62,7 @@ func (a kubernetesAgent) Collect(ctx context.Context) error {
 		return err
 	}
 
-	record := Record{
+	record := v2types.Record{
 		KindVersion: agent.KindVersion{
 			Kind:    "kubernetes",
 			Version: telemetryversion.V2Version,
@@ -93,13 +94,13 @@ func (a kubernetesAgent) Collect(ctx context.Context) error {
 	return a.dataStore.Store(ctx, data)
 }
 
-func nodeFromKubeNode(kn corev1.Node) (Node, error) {
+func nodeFromKubeNode(kn corev1.Node) (v2types.Node, error) {
 	id, err := getID(kn)
 	if err != nil {
-		return Node{}, err
+		return v2types.Node{}, err
 	}
 
-	n := Node{
+	n := v2types.Node{
 		ID:                      id,
 		OperatingSystem:         agent.StrPtr(kn.Status.NodeInfo.OperatingSystem),
 		OSImage:                 agent.StrPtr(kn.Status.NodeInfo.OSImage),
@@ -121,7 +122,7 @@ func nodeFromKubeNode(kn corev1.Node) (Node, error) {
 
 	for _, k := range keys {
 		v := kn.Status.Capacity[corev1.ResourceName(k)]
-		n.Capacity = append(n.Capacity, Resource{
+		n.Capacity = append(n.Capacity, v2types.Resource{
 			Resource: k,
 			Value:    v.String(),
 		})

--- a/pkg/agent/kubernetes/v2/types/record.go
+++ b/pkg/agent/kubernetes/v2/types/record.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2021 The Telemetry Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -12,10 +12,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Telemetry takes the Record schema from Kubernetes spartakus project:
-https://github.com/kubernetes-retired/spartakus/blob/master/pkg/volunteer/kubernetes.go
-and some customized fields are added to fit Telemetry own use cases.
 */
 
 package types

--- a/pkg/agent/kubernetes/v2/types/record.go
+++ b/pkg/agent/kubernetes/v2/types/record.go
@@ -18,7 +18,7 @@ https://github.com/kubernetes-retired/spartakus/blob/master/pkg/volunteer/kubern
 and some customized fields are added to fit Telemetry own use cases.
 */
 
-package v2
+package types
 
 import (
 	"fmt"


### PR DESCRIPTION
**What this PR does / why we need it**:
Our telemetry server, which imports this repository, has a full dependency on all Kubernetes packages, only because this repo has mixed the implementation and the types for each agent.

To make this a bit better, this PR moves all the types into their own packages. Other projects that import the telemetry-client will still, on a go.mod-level, have a dependency on client-go, but I hope that the compiled binary will not.

This is similar to how we deal with types in the machine-controller, e.g. https://github.com/kubermatic/machine-controller/tree/main/pkg/cloudprovider/provider/aws
